### PR TITLE
Fix three code bugs

### DIFF
--- a/torchgeo/datasets/digital_typhoon.py
+++ b/torchgeo/datasets/digital_typhoon.py
@@ -405,9 +405,25 @@ class DigitalTyphoon(NonGeoDataset):
         """Extract the dataset."""
         # Extract tarball
         for suffix in self.md5sums.keys():
-            with tarfile.open(
-                os.path.join(self.root, f'{self.data_root}.tar.gz{suffix}')
-            ) as tar:
+            archive_path = os.path.join(self.root, f'{self.data_root}.tar.gz{suffix}')
+
+            def _is_within_directory(directory: str, target: str) -> bool:
+                """Ensure target path is within the given directory.
+
+                Prevents path traversal when extracting archives by verifying
+                that the resolved target remains under the intended root.
+                """
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+                return os.path.commonprefix([abs_directory, abs_target]) == abs_directory
+
+            with tarfile.open(archive_path) as tar:
+                for member in tar.getmembers():
+                    member_path = os.path.join(self.root, member.name)
+                    if not _is_within_directory(self.root, member_path):
+                        raise RuntimeError(
+                            f'Blocked path traversal attempt in archive: {member.name}'
+                        )
                 tar.extractall(path=self.root)
 
     def plot(

--- a/torchgeo/models/croma.py
+++ b/torchgeo/models/croma.py
@@ -61,7 +61,10 @@ class CROMA(nn.Module):
             )
 
         assert image_size % 8 == 0, 'image_size must be a multiple of 8'
-        assert num_heads % 2 == 0, 'num_heads must be a power of 2'
+        # Ensure num_heads is a power of two (e.g., 1,2,4,8,16,...) not just even
+        assert num_heads > 0 and (num_heads & (num_heads - 1)) == 0, (
+            'num_heads must be a power of 2'
+        )
 
         self.modalities = modalities
         self.encoder_dim = encoder_dim

--- a/torchgeo/models/panopticon.py
+++ b/torchgeo/models/panopticon.py
@@ -23,7 +23,7 @@ class PanopticonPE(nn.Module):
         attn_dim: int,
         embed_dim: int,
         patch_size: int,
-        chnfus_cfg: dict[str, Any] = {},
+        chnfus_cfg: dict[str, Any] | None = None,
         img_size: int = 224,
     ) -> None:
         """Initialize a new Panopticon instance.
@@ -38,6 +38,7 @@ class PanopticonPE(nn.Module):
         super().__init__()
 
         self.conv3d = Conv3dWrapper(patch_size=patch_size, embed_dim=attn_dim)
+        chnfus_cfg = {} if chnfus_cfg is None else chnfus_cfg
         self.chnfus = ChnAttn(**chnfus_cfg, dim=attn_dim)
         self.proj = nn.Linear(attn_dim, embed_dim)
 
@@ -126,8 +127,8 @@ class ChnAttn(nn.Module):
     def __init__(
         self,
         dim: int,
-        chnemb_cfg: dict[str, Any] = {},
-        attn_cfg: dict[str, Any] = {},
+        chnemb_cfg: dict[str, Any] | None = None,
+        attn_cfg: dict[str, Any] | None = None,
         layer_norm: bool = False,
     ) -> None:
         """Initialize a channel attention module.
@@ -140,8 +141,10 @@ class ChnAttn(nn.Module):
         """
         super().__init__()
 
+        chnemb_cfg = {} if chnemb_cfg is None else chnemb_cfg
         self.chnemb = ChnEmb(**chnemb_cfg, embed_dim=dim)
         self.query = nn.Parameter(torch.randn(1, 1, dim))
+        attn_cfg = {} if attn_cfg is None else attn_cfg
         self.xattn = CrossAttnNoQueryProj(dim=dim, **attn_cfg)
 
         if layer_norm:


### PR DESCRIPTION
Fix mutable default arguments, add path traversal protection for tar extraction, and correct the power-of-two assertion for `num_heads`.

Mutable default arguments in `panopticon.py` were changed to prevent shared state between instances. Unsafe tar extraction in `digital_typhoon.py` now includes path traversal checks to mitigate security risks. The `num_heads` assertion in `croma.py` was corrected to ensure it's a true power of two, as required by some attention implementations.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6ca9455-3dea-4f4f-bbbf-070d3d16a31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6ca9455-3dea-4f4f-bbbf-070d3d16a31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

