### PR TITLE
Safely decode .pth shards in CopernicusPretrain and filter before decoding

### DIFF
--- a/tests/datasets/test_copernicus.py
+++ b/tests/datasets/test_copernicus.py
@@ -1,7 +1,9 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
+import io
 import os
+import pickle
 import shutil
 from pathlib import Path
 
@@ -159,6 +161,21 @@ class TestCopernicusPretrain:
         assert x['s5p_o3.pth'].shape == (1, 28, 28)
         assert x['s5p_so2.pth'].shape == (1, 28, 28)
         assert x['dem.pth'].shape == (960, 960)
+
+    def test_safe_decode(self, tmp_path: Path) -> None:
+        class Payload:
+            def __reduce__(self) -> tuple[object, tuple[str]]:
+                return os.system, (f'touch {tmp_path / "unsafe"}',)
+
+        buffer = io.BytesIO()
+        torch.save(Payload(), buffer)
+
+        with pytest.raises(pickle.UnpicklingError):
+            CopernicusPretrain._decode_pth('image.pth', buffer.getvalue())
+        assert not (tmp_path / 'unsafe').exists()
+
+    def test_decode_other_file(self) -> None:
+        assert CopernicusPretrain._decode_pth('metadata.json', b'{}') is None
 
     def test_plot(self, dataset: CopernicusPretrain) -> None:
         x = next(iter(dataset))

--- a/torchgeo/datasets/copernicus/pretrain.py
+++ b/torchgeo/datasets/copernicus/pretrain.py
@@ -5,6 +5,7 @@
 
 import random
 from collections.abc import Iterator
+from io import BytesIO
 from typing import Any, ClassVar
 
 import torch
@@ -104,9 +105,9 @@ class CopernicusPretrain(IterableDataset[Sample]):
         self.dataset = (
             wds.WebDataset(*args, **kwargs)
             .shuffle(10)  # shuffle individual samples before batching
-            .decode()  # decode binary data
-            .map(self._drop_metadata)  # remove non-Tensor metadata
             .select(self._has_all_modalities)  # select samples with all modalities
+            .decode(self._decode_pth)  # safely decode tensor data
+            .map(self._drop_metadata)  # remove non-Tensor metadata
             .map(self._sample_one_local_patch)  # sample one local patch for S1 and S2
             .map(self._sample_one_time_stamp)  # sample one timestamp for all modalities
         )
@@ -138,7 +139,22 @@ class CopernicusPretrain(IterableDataset[Sample]):
 
         return new_sample
 
-    def _has_all_modalities(self, sample: Sample) -> bool:
+    @staticmethod
+    def _decode_pth(key: str, data: bytes) -> object | None:
+        """Safely decode PyTorch tensor data.
+
+        Args:
+            key: File name within the sample.
+            data: Encoded file contents.
+
+        Returns:
+            Decoded data for PyTorch files, otherwise None.
+        """
+        if key.endswith('.pth'):
+            return torch.load(BytesIO(data), weights_only=True)
+        return None
+
+    def _has_all_modalities(self, sample: dict[str, object]) -> bool:
         """Selection function: filter samples with all required modalities.
 
         Args:


### PR DESCRIPTION
### Motivation

- WebDataset decoding was applied unconditionally before sample filtering, allowing `.pth` members to be deserialized (potentially via unsafe pickle paths) before the pipeline could reject incomplete or malicious samples.

### Description

- Reordered the WebDataset pipeline to call `.select(self._has_all_modalities)` before decoding so incomplete samples are rejected prior to any deserialization.
- Replaced the unrestricted `.decode()` call with a custom decoder `._decode_pth` and a `BytesIO` import that calls `torch.load(..., weights_only=True)` for files ending with `.pth`, preventing arbitrary pickle execution while preserving tensor loading.
- Added regression tests in `tests/datasets/test_copernicus.py` including `test_safe_decode` which verifies a malicious pickle payload does not execute and `test_decode_other_file` which ensures non-`.pth` files are left to other decoders.
- Small API/formatting updates to `torchgeo/datasets/copernicus/pretrain.py` and the corresponding test file to wire the new behavior into the dataset pipeline.

### Testing

- Ran `ruff format` and `ruff check` on the modified files and they passed.
- Verified the modified files compile with `python -m compileall` and ran `git diff --check` with no issues.
- Attempted `pytest -q tests/datasets/test_copernicus.py -k CopernicusPretrain`, but collection was blocked because the environment lacked `matplotlib`, so the new tests could not be executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a712840e394832caebb1c2c6154b3e0)